### PR TITLE
DRAFT: Feat/add stagingimage hub to pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/intro-site:latest
+          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/intro-website:latest
           build-args: |
             BUILD_NUMBER=${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/intro-website:latest
+          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ vars.HARBOR_PROJECT }}/intro-website:latest
           build-args: |
             BUILD_NUMBER=${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           webhook_secret: ${{ secrets.AAS_PRE_SHARED_KEY }}
 
   dockerize:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
+    # if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
     name: Build and push Docker image to Harbor
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/astro-site:latest
+          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/intro-site:latest
           build-args: |
             BUILD_NUMBER=${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
   dockerize:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
-    name: Package Docker image as artifact
+    name: Build and push Docker image to Harbor
     needs: build
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'development' }}
@@ -79,19 +79,19 @@ jobs:
         with:
           name: website-build-static-files
           path: dist/
-      
-      - name: Build Docker image
-        run: |
-          docker build -t astro-site:${{ github.sha }} . --build-arg BUILD_NUMBER=${{ github.run_id }}
 
-      # as we do not have a proper docker registry yet; just save it as an artifact. TODO: make this push to our self-hosted docker registry.
-      - name: Save Docker image as .tar
-        run: |
-          docker save astro-site | gzip > astro-site.tar.gz
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+      - name: Log in to Harbor registry
+        uses: docker/login-action@v3
         with:
-          name: astro-site-docker-image
-          path: astro-site.tar.gz
-          retention-days: 30
+          registry: ${{ secrets.HARBOR_REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ secrets.HARBOR_PROJECT }}/astro-site:latest
+          build-args: |
+            BUILD_NUMBER=${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Log in to Harbor registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.HARBOR_REGISTRY }}
+          registry: ${{ vars.HARBOR_REGISTRY }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
@@ -92,6 +92,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.HARBOR_REGISTRY }}/${{ vars.HARBOR_PROJECT }}/intro-website:latest
+          tags: ${{ vars.HARBOR_REGISTRY }}/${{ vars.HARBOR_PROJECT }}/intro-website:latest
           build-args: |
             BUILD_NUMBER=${{ github.run_id }}


### PR DESCRIPTION
As an MVP, i want to be able to *always* push a build to the second staging server. In later configurations, the right way to go (in my opinion) would be to have DEV, or PROD prefix for the secrets. all merge request pipelines manually go to staging. All development branch pipelines automatically go to staging. All ma[in/ster] pipelines go to prod. Just a ctrl c+v of the pipeline, arguably in n different files (dev.yml and prod.yml, or MR.yml, development.yaml, main.yaml, etc.)